### PR TITLE
Depend on cdap-maven-plugin 1.0.0, instead of 1.0.0-SNAPSHOT.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -362,7 +362,7 @@
         <plugin>
           <groupId>co.cask</groupId>
           <artifactId>cdap-maven-plugin</artifactId>
-          <version>1.0.0-SNAPSHOT</version>
+          <version>1.0.0</version>
           <configuration>
             <cdapArtifacts>
               <parent>system:cdap-data-streams[4.3.0-SNAPSHOT,5.0.0)</parent>


### PR DESCRIPTION
Depend on cdap-maven-plugin 1.0.0, instead of 1.0.0-SNAPSHOT.
This change is needed because the snapshot JAR is no longer available:
"Plugin co.cask:cdap-maven-plugin:1.0.0-SNAPSHOT or one of its dependencies could not be resolved: Could not find artifact co.cask:cdap-maven-plugin:jar:1.0.0-SNAPSHOT"

User on google group had the issue: https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/cdap-user/6trrK8DybsU/qq6bnelQBgAJ